### PR TITLE
Added support for different delimiters in paste command 

### DIFF
--- a/README
+++ b/README
@@ -45,7 +45,7 @@ II. Description
   This scheme has two major drawbacks, however:
 
   1. Changes to the data format require significant updates to data readers, as
-     well as a data verisoning scheme. Examples:
+     well as a data versioning scheme. Examples:
     a) Suppose one later improves the experiment and needs to write data in
        0.05 degree bins. This requires adding one bit to both the azimuth and
        zenith fields.

--- a/include/xcdf/utility/XCDFUtility.h
+++ b/include/xcdf/utility/XCDFUtility.h
@@ -438,8 +438,16 @@ class CSVInputHandler {
 
     CSVInputHandler(XCDFFile& f,
                     std::istream& in) : f_(f),
-                                        in_(in) {
+                                        in_(in),
+                                        delim_(',') {
+      ProcessFieldDefs();
+    }
 
+    CSVInputHandler(XCDFFile& f,
+                    std::istream& in,
+                    char& delim) : f_(f),
+                                in_(in),
+                                delim_(delim) {
       ProcessFieldDefs();
     }
 
@@ -523,6 +531,7 @@ class CSVInputHandler {
 
     XCDFFile& f_;
     std::istream& in_;
+    char delim_;
 
     void ProcessFieldDefs() {
 
@@ -541,14 +550,14 @@ class CSVInputHandler {
       std::stringstream sstream(currentLine_);
       std::string currentString;
 
-      while (std::getline(sstream, currentString, ',')) {
+      while (std::getline(sstream, currentString, delim_)) {
 
         currentParsedLine_.push_back(currentString);
       }
 
       // Check for an empty delimiter
       if (currentLine_.size() > 0) {
-        if (currentLine_[currentLine_.size() - 1] == ',') {
+        if (currentLine_[currentLine_.size() - 1] == delim_) {
           currentParsedLine_.push_back("");
         }
       }


### PR DESCRIPTION
xcdf-utility paste now has an option -d for the delimiter of the csv file. 
This was tested with " " and tabs the two common examples I could think off. 
The new option is backwards compatible with the old version and if the delimiter flag is not specified it defaults to the old behavior of using commas. 
