### PR TITLE
Fixing the remove-comments command so it correctly parses the output option.

### DIFF
--- a/utilities/XCDFUtility.cc
+++ b/utilities/XCDFUtility.cc
@@ -932,7 +932,8 @@ int main(int argc, char** argv) {
   std::string delimeter = ",";
   int currentArg = 2;
 
-  if (!verb.compare("recover")) {
+  if (!verb.compare("recover") || 
+      !verb.compare("remove-comments")) {
 
     if (currentArg < argc) {
 
@@ -1033,24 +1034,6 @@ int main(int argc, char** argv) {
       }
     }
   }
-
-  if (!verb.compare("remove-comments")) {
-    if (currentArg < argc) {
-
-      std::string out(argv[currentArg]);
-      if (!out.compare("-o")) {
-
-        if (++currentArg == argc) {
-          PrintUsage();
-          exit(1);
-        }
-
-        fout.open(argv[currentArg++]);
-        outstream = &fout;
-      }
-    }
-  }
- 
 
   while (currentArg < argc) {
     infiles.push_back(std::string(argv[currentArg++]));

--- a/utilities/XCDFUtility.cc
+++ b/utilities/XCDFUtility.cc
@@ -992,7 +992,7 @@ int main(int argc, char** argv) {
 
       std::string out(argv[currentArg]);
       if (!out.compare("-d")) {
-        
+
         if(++currentArg == argc) {
           PrintUsage();
           exit(1);
@@ -1033,6 +1033,24 @@ int main(int argc, char** argv) {
       }
     }
   }
+
+  if (!verb.compare("remove-comments")) {
+    if (currentArg < argc) {
+
+      std::string out(argv[currentArg]);
+      if (!out.compare("-o")) {
+
+        if (++currentArg == argc) {
+          PrintUsage();
+          exit(1);
+        }
+
+        fout.open(argv[currentArg++]);
+        outstream = &fout;
+      }
+    }
+  }
+ 
 
   while (currentArg < argc) {
     infiles.push_back(std::string(argv[currentArg++]));


### PR DESCRIPTION
There is a small problem with xcdf-utility I added the option so delete-comments now accepts the -o option. 