### PR TITLE
NumericalExpression.h extra include so it can be included stand-alone

### DIFF
--- a/include/xcdf/utility/NumericalExpression.h
+++ b/include/xcdf/utility/NumericalExpression.h
@@ -30,6 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <xcdf/utility/Symbol.h>
 #include <xcdf/utility/NodeDefs.h>
 #include <xcdf/utility/Expression.h>
+#include <xcdf/XCDFPtr.h>
+
 
 #include <vector>
 #include <list>


### PR DESCRIPTION
Probably overkill but I'm new to github trying to figure out how it all works. 

It's a genuine (tiny) issue though.