### PR TITLE
Fix README CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # XCDF: The eXplicitly Compacted Data Format
 
-![CMake](https://github.com/jimbraun/XCDF/actions/workflows/CI_cmake_build.yml/badge.svg?branch=feature-1)
-![scikit-build](https://github.com/jimbraun/XCDF/actions/workflows/CI_scikit_build.yml/badge.svg?branch=feature-1)
+![CMake](https://github.com/jimbraun/XCDF/actions/workflows/CI_cmake_build.yml/badge.svg?branch=master)
+![scikit-build](https://github.com/jimbraun/XCDF/actions/workflows/CI_scikit_build.yml/badge.svg?branch=master)
 [![readthedocs](https://readthedocs.org/projects/xcdf/badge/?version=latest)](https://xcdf.readthedocs.io/en/latest/?badge=latest)
 
 ## Overview

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,14 @@
 XCDF: The eXplicitly Compacted Data Format
 ==========================================
 
+.. |CMake CI| image:: https://github.com/jimbraun/XCDF/actions/workflows/CI_cmake_build.yml/badge.svg?branch=master
+  :target: https://github.com/jimbraun/XCDF/actions/workflows/CI_cmake_build.yml?query=branch%3Amaster
+
+.. |scikit-build CI| image:: https://github.com/jimbraun/XCDF/actions/workflows/CI_scikit_build.yml/badge.svg?branch=master
+  :target: https://github.com/jimbraun/XCDF/actions/workflows/CI_scikit_build.yml?query=branch%3Amaster
+
+|CMake CI| |scikit-build CI|
+
 The *eXplicitly Compacted Data Format* (XCDF) is a binary data format designed
 to store data fields with user-specified accuracy.  The library uses
 bit-packing to store the field at the given accuracy for a given set of


### PR DESCRIPTION
I noticed that the CI badges in the README are not working and the cause is that I copy-pasted them from an example line without updating the name of the target branch.

I also added them to the documentation's landing page (that badge is still red because in order to enable the online build of the documentation this repository needs to be connected to ReadTheDocs).