### PR TITLE
Fix ReadTheDocs docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,4 +26,7 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,11 +5,15 @@
 # Required
 version: 2
 
+# conda virtual environment
+conda:
+  environment: environment.yml
+
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "mambaforge-4.10"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-breathe
-exhale
-furo
-graphviz
-sphinx
-sphinx-copybutton
-sphinx-automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,11 @@ python_requires = >=3.7
 [options.extras_require]
 tests = 
     pytest
+docs =
+    breathe
+    exhale
+    furo
+    graphviz
+    sphinx
+    sphinx-copybutton
+    sphinx-automodapi


### PR DESCRIPTION
I noticed that I didn't tell ReadTheDocs to install the XCDF python package first (at least not from the YAML config file, which should have priority).

I also set to use a mamba virtual environment and use that, since I am not sure if doxygen is installed on the remote machines (for sure we cannot install it from pip).

I am not sure if it will be successful at the first try, but I set ReadTheDocs to build also every PR, so it should be possible to peek at the documentation of each PR before it gets merged.
See here https://docs.readthedocs.io/en/stable/pull-requests.html.

We are still missing the webhook, though: without that the builds won't be automatic (see #97).