### PR TITLE
Add support for writing from Python3

### DIFF
--- a/.github/workflows/CI_scikit_build.yml
+++ b/.github/workflows/CI_scikit_build.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install doc dependencies
         run: |
-          pip install .
+          pip install '.[docs]'
           git describe --tags
           python -c 'import xcdf; print(xcdf.__version__)'
 

--- a/docs/source/api/python_index.rst
+++ b/docs/source/api/python_index.rst
@@ -25,5 +25,6 @@ containing
 .. automodapi:: xcdf.xcdf
     :no-heading:
     :include-all-objects:
+    :no-inheritance-diagram:
     
     

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,9 +39,13 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.viewcode",
     "sphinx_automodapi.automodapi",
+    "sphinx_exec_code",
     "breathe",
     "exhale",
 ]
+
+exec_code_working_dir = "./examples"
+exec_code_example_dir = "./examples"
 
 autosummary_generate = True
 autosummary_ignore_module_all = True

--- a/docs/source/examples/py3_bindings_read.py
+++ b/docs/source/examples/py3_bindings_read.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from pprint import pprint
+from xcdf import File
+
+test_file = Path.cwd() / Path("example_file_py3bindings.xcd")
+
+events = {}
+
+with File(str(test_file), "r") as input_file:
+    file_header = input_file.comments
+    for event_index, event in enumerate(input_file):
+        events[event_index] = event
+
+print("FILE HEADER\n===========\n")
+print(file_header)
+
+print("\nEVENTS\n======\n")
+pprint(events, width=5)

--- a/docs/source/examples/py3_bindings_write.py
+++ b/docs/source/examples/py3_bindings_write.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import numpy as np
+from xcdf import File
+
+# Open a new file for writing
+test_file = Path.cwd() / Path("example_file_py3bindings.xcd")
+with File(str(test_file), "w") as f:
+    # Define the data fields
+
+    field_A = f.allocate_uint_field("A", 1, "")
+    field_B = f.allocate_float_field("B", 0.1, "A")
+
+    # Add data for the first event/row
+
+    field_A.add(4)
+
+    # Field "B" is a child of "A", so it needs to contain
+    # as many values as the entry in "A" says for this event
+    for i in np.arange(0, 1, 0.25):
+        field_B.add(i)
+
+    f.write()
+
+    # Add data for the second event/row
+
+    field_A.add(1)
+    field_B.add(6.0)
+
+    f.write()
+
+    # Add a final comment in the file header
+    f.add_comment("This is a test comment")

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -108,17 +108,37 @@ Python interface
 
     After XCDF v3.00.03 support for Python2 has been dropped.
 
-This is a simple example of how to open an XCDF file and
-loads its contents in Python3 and numpy data structures,
+This is a simple tutorial on how to write an XCDF file and
+read its contents in Python3 using numpy data structures.
 
-.. code-block:: python
+Write an XCDF file
+^^^^^^^^^^^^^^^^^^
 
-    import numpy as np
-    import xcdf
+First we will write a file containing two events (rows),
+each defined by two fields, ``A`` and ``B``.
+The latter is a child of the former, which means that
+for each event the value of ``A`` dictates
+how many elements should be contained in ``B``.
 
-    events = {}
+In particular we declare ``A`` as a integer-type field
+and ``B`` a float-type field with a resolution of 0.1.
 
-    with File("some_file.xcd", "r") as input_file:
-        file_header = input_file.comments
-        for event_index, event in enumerate(input_file):
-            events[event_index] = event
+We will also write a small comment to the file header
+at the end.
+
+.. exec_code::
+   :filename: py3_bindings_write.py
+
+Read an XCDF file
+^^^^^^^^^^^^^^^^^
+
+Now let's re-open the same file and read back what we wrote in it.
+
+Notice that, when read back, the data associated to the ``B`` field
+of the first event is the array ``[0. , 0.3, 0.5, 0.8]``
+and not what we injected at writing time, ``[0.  , 0.25, 0.5 , 0.75])``,
+because we declared (i.e. allocated) the ``B`` field with a resolution
+of ``0.1``.
+
+.. exec_code::
+   :filename: py3_bindings_read.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,12 @@ python_requires = >=3.7
 [options.extras_require]
 tests = 
     pytest
+docs =
+    breathe
+    exhale
+    furo
+    graphviz
+    sphinx
+    sphinx-copybutton
+    sphinx-automodapi
+    sphinx-exec-code

--- a/src/pybindings/xcdf/xcdf.cpp
+++ b/src/pybindings/xcdf/xcdf.cpp
@@ -1,175 +1,241 @@
-#include <sstream>
-#include <string>
+//! Python bindings for XCDF using pybind11.
+
 #include <cstdio>
 #include <limits>
+#include <sstream>
+#include <string>
 
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/numpy.h>
 
-#include <xcdf/XCDF.h>
 #include "xcdf/XCDFFieldDescriptor.h"
 #include "xcdf/XCDFFile.h"
+#include <xcdf/XCDFField.h>
 
 namespace py = pybind11;
 
-std::string getVersion()
-{
-    std::stringstream ss;
-    ss << XCDF_MAJOR_VERSION
-       << "." << XCDF_MINOR_VERSION
-       << "." << XCDF_PATCH_VERSION;
-    return ss.str();
+std::string getVersion() {
+  std::stringstream ss;
+  ss << XCDF_MAJOR_VERSION << "." << XCDF_MINOR_VERSION << "."
+     << XCDF_PATCH_VERSION;
+  return ss.str();
 }
 
-void write_test_file(const std::string &path)
-{
-    XCDFFile f(path.c_str(), "w");
+void write_test_file(const std::string &path) {
+  XCDFFile f(path.c_str(), "w");
 
-    XCDFUnsignedIntegerField field1 =
-        f.AllocateUnsignedIntegerField("field1", 1);
-    XCDFUnsignedIntegerField field2 =
-        f.AllocateUnsignedIntegerField("field2", 1, "field1");
-    XCDFFloatingPointField field3 =
-        f.AllocateFloatingPointField("field3", 0.1);
-    XCDFFloatingPointField field4 =
-        f.AllocateFloatingPointField("field4", 0.1);
-    XCDFFloatingPointField field5 =
-        f.AllocateFloatingPointField("field5", 0.1);
-    XCDFUnsignedIntegerField field6 =
-        f.AllocateUnsignedIntegerField("field6", 1);
-    XCDFFloatingPointField field7 =
-        f.AllocateFloatingPointField("field7", 0.);
-    // 2D vector
-    XCDFUnsignedIntegerField field8 =
-        f.AllocateUnsignedIntegerField("field8", 1, "field2");
-    // 3D vector
-    XCDFFloatingPointField field9 =
-        f.AllocateFloatingPointField("field9", 0.5, "field8");
-    // Header alias
-    f.CreateAlias("testAlias", "field1 + 1");
+  XCDFUnsignedIntegerField field1 = f.AllocateUnsignedIntegerField("field1", 1);
+  XCDFUnsignedIntegerField field2 =
+      f.AllocateUnsignedIntegerField("field2", 1, "field1");
+  XCDFFloatingPointField field3 = f.AllocateFloatingPointField("field3", 0.1);
+  XCDFFloatingPointField field4 = f.AllocateFloatingPointField("field4", 0.1);
+  XCDFFloatingPointField field5 = f.AllocateFloatingPointField("field5", 0.1);
+  XCDFUnsignedIntegerField field6 = f.AllocateUnsignedIntegerField("field6", 1);
+  XCDFFloatingPointField field7 = f.AllocateFloatingPointField("field7", 0.);
+  // 2D vector
+  XCDFUnsignedIntegerField field8 =
+      f.AllocateUnsignedIntegerField("field8", 1, "field2");
+  // 3D vector
+  XCDFFloatingPointField field9 =
+      f.AllocateFloatingPointField("field9", 0.5, "field8");
+  // Header alias
+  f.CreateAlias("testAlias", "field1 + 1");
 
-    field1 << 2;
-    field2 << 1 << 1;
-    field3 << 0.1;
-    field4 << 5.;
-    field5 << 5.;
-    field6 << 0xDEADBEEFDEADBEEFULL;
-    field7 << 0.12;
-    field8 << 2 << 1;
-    field9 << 1. << 2. << 3.;
+  field1 << 2;
+  field2 << 1 << 1;
+  field3 << 0.1;
+  field4 << 5.;
+  field5 << 5.;
+  field6 << 0xDEADBEEFDEADBEEFULL;
+  field7 << 0.12;
+  field8 << 2 << 1;
+  field9 << 1. << 2. << 3.;
 
-    f.Write();
+  f.Write();
 
+  field1 << 2;
+  field2 << 1 << 3;
+  field3 << 0.3;
+
+  // Write a NaN into field4
+  field4 << std::numeric_limits<double>::signaling_NaN();
+
+  // Write an inf into field5
+  field5 << std::numeric_limits<double>::infinity();
+
+  field6 << 0xDEADBEEFDEADBEEFULL;
+
+  field7 << 0.12;
+
+  field8 << 2 << 2 << 1 << 1;
+  field9 << 1. << 2. << 3. << 4. << 5. << 6.;
+
+  f.Write();
+
+  for (int k = 0; k < 1000; k++) {
     field1 << 2;
     field2 << 1 << 3;
     field3 << 0.3;
-
-    // Write a NaN into field4
     field4 << std::numeric_limits<double>::signaling_NaN();
-
-    // Write an inf into field5
     field5 << std::numeric_limits<double>::infinity();
-
     field6 << 0xDEADBEEFDEADBEEFULL;
-
     field7 << 0.12;
-
     field8 << 2 << 2 << 1 << 1;
     field9 << 1. << 2. << 3. << 4. << 5. << 6.;
-
     f.Write();
+  }
 
-    for (int k = 0; k < 1000; k++)
-    {
-        field1 << 2;
-        field2 << 1 << 3;
-        field3 << 0.3;
-        field4 << std::numeric_limits<double>::signaling_NaN();
-        field5 << std::numeric_limits<double>::infinity();
-        field6 << 0xDEADBEEFDEADBEEFULL;
-        field7 << 0.12;
-        field8 << 2 << 2 << 1 << 1;
-        field9 << 1. << 2. << 3. << 4. << 5. << 6.;
-        f.Write();
-    }
+  f.AddComment("test file");
 
-    f.AddComment("test file");
-
-    // Trailer alias
-    f.CreateAlias("testTrailerAlias", "double(testAlias + 2)");
+  // Trailer alias
+  f.CreateAlias("testTrailerAlias", "double(testAlias + 2)");
 }
 
-struct DictBuilder
-{
-    py::dict data;
+struct DictBuilder {
+  py::dict data;
 
-    template <typename T>
-    void operator()(const XCDFField<T> &field)
-    {
+  template <typename T> void operator()(const XCDFField<T> &field) {
 
-        py::str key = field.GetName();
-        // return vector fields as numpy arrays
-        if (field.HasParent())
-        {
-            py::array_t<T> array(field.GetSize());
-            py::buffer_info buffer = array.request();
-            T *ptr = static_cast<T *>(buffer.ptr);
+    py::str key = field.GetName();
+    // return vector fields as numpy arrays
+    if (field.HasParent()) {
+      py::array_t<T> array(field.GetSize());
+      py::buffer_info buffer = array.request();
+      T *ptr = static_cast<T *>(buffer.ptr);
 
-            for (size_t i = 0; i < field.GetSize(); i++)
-            {
-                ptr[i] = field[i];
-            }
+      for (size_t i = 0; i < field.GetSize(); i++) {
+        ptr[i] = field[i];
+      }
 
-            data[key] = array;
-            // scalar fields as python objects (None if not set)
-        }
-        else
-        {
-            if (field.GetSize() == 0)
-            {
-                data[key] = py::none();
-            }
-            else
-            {
-                data[key] = field[0];
-            }
-        }
+      data[key] = array;
+      // scalar fields as python objects (None if not set)
+    } else {
+      if (field.GetSize() == 0) {
+        data[key] = py::none();
+      } else {
+        data[key] = field[0];
+      }
     }
+  }
 };
 
-PYBIND11_MODULE(xcdf, m)
-{
+PYBIND11_MODULE(xcdf, m) {
 
-    m.attr("__version__") = getVersion();
+  m.attr("__version__") = getVersion();
 
-    m.def("write_test_file", &write_test_file, "Write an XCDF test file in C++.");
+  m.def("write_test_file", &write_test_file, "Write an XCDF test file in C++.");
 
-    py::class_<XCDFFieldDescriptor>(m, "FieldDescriptor", "Class that summarizes the properties of a field.")
-        .def("__repr__", [](XCDFFieldDescriptor &self)
-             {
-            std::stringstream ss;
-            ss << "FieldDescriptor(name=" << self.name_
+  // XCDFUnsignedIntegerField
+  py::class_<XCDFField<uint64_t>>(m, "XCDFUnsignedIntegerField",
+                                  "Field with unsigned integer data.")
+      .def("add", &XCDFField<uint64_t>::Add);
+
+  // XCDFSignedIntegerField
+  py::class_<XCDFField<int64_t>>(m, "XCDFSignedIntegerField",
+                                 "Field with signed integer data.")
+      .def("add", &XCDFField<int64_t>::Add);
+
+  // XCDFFloatingPointField
+  py::class_<XCDFField<double>>(m, "XCDFFloatingPointField",
+                                "Field with floating point data.")
+      .def("add", &XCDFField<double>::Add);
+
+  py::class_<XCDFFieldDescriptor>(
+      m, "FieldDescriptor", "Class that summarizes the properties of a field.")
+      .def("__repr__",
+           [](XCDFFieldDescriptor &self) {
+             std::stringstream ss;
+             ss << "FieldDescriptor(name=" << self.name_
                 << ", type=" << static_cast<int>(self.type_)
                 << ", parent=" << self.parentName_
-                << ", raw_resolution=" << self.rawResolution_
-                << ")";
+                << ", raw_resolution=" << self.rawResolution_ << ")";
 
-            return ss.str(); })
-        .def_property_readonly("name", [](XCDFFieldDescriptor &self)
-                               { return self.name_; })
-        .def_property_readonly("type", [](XCDFFieldDescriptor &self)
-                               { return self.type_; })
-        .def_property_readonly("parent", [](XCDFFieldDescriptor &self)
-                               { return self.parentName_; })
-        .def_property_readonly("raw_resolution", [](XCDFFieldDescriptor &self)
-                               { return self.rawResolution_; });
+             return ss.str();
+           })
+      .def_property_readonly(
+          "name", [](XCDFFieldDescriptor &self) { return self.name_; })
+      .def_property_readonly(
+          "type", [](XCDFFieldDescriptor &self) { return self.type_; })
+      .def_property_readonly(
+          "parent", [](XCDFFieldDescriptor &self) { return self.parentName_; })
+      .def_property_readonly("raw_resolution", [](XCDFFieldDescriptor &self) {
+        return self.rawResolution_;
+      });
 
-    py::class_<XCDFFile>(m, "File", "XCDF file handle with iterator access to stored records.")
-        .def(py::init<const char *, const char *>(),
-             py::arg("path"), py::arg("mode") = "r",
-             "Open a disk file in the specified mode.")
-        .def("close", &XCDFFile::Close, R"pbdoc(Close the File instance.
+  py::class_<XCDFFile>(
+      m, "File", "XCDF file handle with iterator access to stored records.")
+
+      .def(py::init<const char *, const char *>(), py::arg("path"),
+           py::arg("mode") = "r", R"pbdoc(
+            Open a disk file in the specified mode.
+
+            Parameters
+            ----------
+            path : `str`
+                Path of the file on disk.
+            mode : `str`
+                Mode in which the file is opened.
+                It defaults to 'r' which means open for reading in text mode.
+                Other common values are 'w' for writing (truncating the file if it already exists),
+                'x' for exclusive creation,
+                and 'a' for appending
+                (which on some Unix systems,
+                means that all writes append to the end of the file regardless of
+                the current seek position).
+            )pbdoc")
+
+      .def("add_comment", &XCDFFile::AddComment,
+           "Add a string comment to the file")
+
+      .def("allocate_float_field", &XCDFFile::AllocateFloatingPointField,
+           R"pbdoc(
+        Allocate a field with floating point data.
+        
+        Parameters
+        ----------
+        name : `str`
+            Name of the field.
+        resolution: `float`
+            The floating point resolution needed in the field.
+            If resolution <= 0. is specified, the full 64-bit
+            double will be written to file.
+        parent_name: `str`
+            If the field is a vector, this is the name of the field that
+            contains the number of entries in the vector.
+        )pbdoc")
+
+      .def("allocate_uint_field", &XCDFFile::AllocateUnsignedIntegerField,
+           R"pbdoc(
+        Allocate a field with unsigned integer data.
+        
+        Parameters
+        ----------
+        name : `str`
+            Name of the field.
+        resolution: `int`
+            The (positive) integer resolution needed in the field
+        parent_name: `str`
+            If the field is a vector, this is the name of the field that
+            contains the number of entries in the vector.
+        )pbdoc")
+
+      .def("allocate_int_field", &XCDFFile::AllocateSignedIntegerField,
+           R"pbdoc(
+        Allocate a field with signed integer data.
+        
+        Parameters
+        ----------
+        name : `str`
+            Name of the field.
+        resolution: `int`
+            The (positive) integer resolution needed in the field
+        parent_name: `str`
+            If the field is a vector, this is the name of the field that
+            contains the number of entries in the vector.
+        )pbdoc")
+
+      .def("close", &XCDFFile::Close, R"pbdoc(Close the File instance.
         
         Underlying file/stream resources will be closed
         and released unless the stream open/close constructors were invoked.
@@ -177,71 +243,96 @@ PYBIND11_MODULE(xcdf, m)
         If writing, do end checks to ensure all data is written out to file.
 
         )pbdoc")
-        .def("seek", &XCDFFile::Seek, py::arg("absolute event position"), "Seek to the given event in the file by absolute position.")
-        .def("rewind", &XCDFFile::Rewind, "Return the file to a state where calling Read() gives the starting event, if possible.")
-        .def("__len__", &XCDFFile::GetEventCount, "Return the total number of events in the file.")
-        .def("__in__", &XCDFFile::HasField, "Check if the file contains the given field.")
-        .def(
-            "check", [](XCDFFile &self)
-            {
-            while (self.Read()) { /* Do nothing */ }
-            self.Close(); },
-            "Check file by allow internal checksum verification to detect errors.")
-        .def_property_readonly("version", &XCDFFile::GetVersion, "Get the version number of the current open file.")
-        .def_property_readonly("n_fields", &XCDFFile::GetNFields, "Get the total number of fields allocated in the file.")
-        .def_property_readonly("is_simple", &XCDFFile::IsSimple, "Check if the underlying file has a trailer pointer that can be seek to.")
-        .def_property_readonly("is_open", &XCDFFile::IsOpen, "Check if the file is currently open.")
-        .def_property_readonly(
-            "comments", [](XCDFFile &self)
-            {
+
+      .def("write", &XCDFFile::Write,
+           "Write one event to the uncompressed buffer.")
+
+      .def("seek", &XCDFFile::Seek, py::arg("absolute event position"),
+           "Seek to the given event in the file by absolute position.")
+      .def("rewind", &XCDFFile::Rewind,
+           "Return the file to a state where calling Read() gives the starting "
+           "event, if possible.")
+      .def("__len__", &XCDFFile::GetEventCount,
+           "Return the total number of events in the file.")
+      .def("__in__", &XCDFFile::HasField,
+           "Check if the file contains the given field.")
+      .def(
+          "check",
+          [](XCDFFile &self) {
+            while (self.Read()) { /* Do nothing */
+            }
+            self.Close();
+          },
+          "Check file by allow internal checksum verification to detect "
+          "errors.")
+      .def_property_readonly("version", &XCDFFile::GetVersion,
+                             "Get the version number of the current open file.")
+      .def_property_readonly(
+          "n_fields", &XCDFFile::GetNFields,
+          "Get the total number of fields allocated in the file.")
+      .def_property_readonly("is_simple", &XCDFFile::IsSimple,
+                             "Check if the underlying file has a trailer "
+                             "pointer that can be seek to.")
+      .def_property_readonly("is_open", &XCDFFile::IsOpen,
+                             "Check if the file is currently open.")
+      .def_property_readonly(
+          "comments",
+          [](XCDFFile &self) {
             std::vector<std::string> comments;
             comments.reserve(self.GetNComments());
-            for (auto it = self.CommentsBegin(); it != self.CommentsEnd(); it++) {
-                comments.push_back(*it);
+            for (auto it = self.CommentsBegin(); it != self.CommentsEnd();
+                 it++) {
+              comments.push_back(*it);
             }
-            return comments; },
-            "Get the XCDF file comments (file header)")
-        .def_property_readonly(
-            "fields", [](XCDFFile &self)
-            {
+            return comments;
+          },
+          "Get the XCDF file comments (file header)")
+      .def_property_readonly(
+          "fields",
+          [](XCDFFile &self) {
             std::vector<XCDFFieldDescriptor> fields;
             fields.reserve(self.GetNFields());
-            for (auto it = self.FieldDescriptorsBegin(); it != self.FieldDescriptorsEnd(); it++) {
-                fields.push_back(*it);
+            for (auto it = self.FieldDescriptorsBegin();
+                 it != self.FieldDescriptorsEnd(); it++) {
+              fields.push_back(*it);
             }
-            return fields; },
-            "Get the fields contained in the file.")
-        .def_property_readonly(
-            "field_names", [](XCDFFile &self)
-            {
+            return fields;
+          },
+          "Get the fields contained in the file.")
+      .def_property_readonly(
+          "field_names",
+          [](XCDFFile &self) {
             std::vector<std::string> names;
             names.reserve(self.GetNFields());
-            for (auto field = self.FieldDescriptorsBegin(); field != self.FieldDescriptorsEnd(); field++) {
-                names.push_back(field->name_);
+            for (auto field = self.FieldDescriptorsBegin();
+                 field != self.FieldDescriptorsEnd(); field++) {
+              names.push_back(field->name_);
             }
-            return names; },
-            "Get the list of field names contained in the file.")
-        .def(
-            "__iter__", [](XCDFFile &self)
-            { return &self; },
-            "Iterate along the file.")
-        .def(
-            "__next__", [](XCDFFile &self)
-            {
+            return names;
+          },
+          "Get the list of field names contained in the file.")
+      .def(
+          "__iter__", [](XCDFFile &self) { return &self; },
+          "Iterate along the file.")
+      .def(
+          "__next__",
+          [](XCDFFile &self) {
             int ret = self.Read();
             if (ret == 0) {
-                throw pybind11::stop_iteration();
+              throw pybind11::stop_iteration();
             }
             DictBuilder builder;
             self.ApplyFieldVisitor(builder);
-            return builder.data; },
-            "Get to the next event.")
-        .def(
-            "__enter__", [](XCDFFile &self)
-            { return &self; },
-            "Enter the runtime context related to the file object")
-        .def(
-            "__exit__", [&](XCDFFile &r, void *exc_type, void *exc_value, void *traceback)
-            { r.Close(); },
-            "Exit the runtime context related to this object.");
+            return builder.data;
+          },
+          "Get to the next event.")
+      .def(
+          "__enter__", [](XCDFFile &self) { return &self; },
+          "Enter the runtime context related to the file object")
+      .def(
+          "__exit__",
+          [&](XCDFFile &r, void *exc_type, void *exc_value, void *traceback) {
+            r.Close();
+          },
+          "Exit the runtime context related to this object.");
 }


### PR DESCRIPTION
This Pull Request expands the current bindings based on pybind11 with basic writing API.

The exposed API are the definitions and allocations of fields for unsigned and signed integers and floating point data.

A new unit test for writing has been added to the _pytest_ suite.

The documentation has been improved with more docstrings and example code for writing and reading from/to Python3 which is automatically executed at build time with the [sphinx-exec-code](https://sphinx-exec-code.readthedocs.io/en/latest/) extension for Sphinx.

#### Related issues

I am not sure if the contribution in this PR covers all use cases; currently what I can see is,

- #79, in which I should have done everything but exposing the ``Get`` method which is anyway more related to reading than writing (could be a separate PR if needed) and the support for appending more data (which I can do here or in a dedicated PR)
- #94 (which refers to #85), if I am not wrong this is not possible in the first place...from the source code, it seems to be not possible to add a new field to an existing file (if I understood correctly what the users were asking)
