### PR TITLE
Add Python3 append mode unit test and documentation example

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,10 +10,18 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
+# import os
+# import sys
 
-sys.path.insert(0, os.path.abspath("../../"))
+# sys.path.insert(0, os.path.abspath("../../"))
+from pathlib import Path
+
+
+# Remove example files from documentation before compiling again
+examples = Path(__file__).parent / "examples"
+example_file = examples / "example_file_py3bindings.xcd"
+if example_file.exists():
+    example_file.unlink()
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/examples/py3_bindings_append.py
+++ b/docs/source/examples/py3_bindings_append.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from pprint import pprint
+from xcdf import File
+
+test_file = Path.cwd() / Path("example_file_py3bindings.xcd")
+
+# You can define field properties as tuples
+# to re-use them when appending multiple times
+field_A_properties = ("A", 1, "")
+field_B_properties = ("B", 0.1, "A")
+
+
+# Re-open the file, but in 'append' mode
+with File(str(test_file), "a") as same_file:
+    # Re-allocate the same data field but for this file
+
+    field_A = same_file.allocate_uint_field(*field_A_properties)
+    field_B = same_file.allocate_float_field(*field_B_properties)
+
+    # Add data for the second event/row
+
+    field_A.add(1)
+
+    field_B.add(5)
+
+    same_file.write()
+
+# Let's add more data
+with File(str(test_file), "a") as again_same_file:
+    # Re-allocate the same data field but for this file
+
+    field_A = again_same_file.allocate_uint_field(*field_A_properties)
+    field_B = again_same_file.allocate_float_field(*field_B_properties)
+
+    # Add data for the second event/row
+
+    field_A.add(2)
+
+    field_B.add(23)
+    field_B.add(34)
+
+    again_same_file.write()
+
+# Read back and print contents
+events = {}
+with File(str(test_file), "r") as input_file:
+    file_header = input_file.comments
+    for event_index, event in enumerate(input_file):
+        events[event_index] = event
+
+print("FILE HEADER\n===========\n")
+print(file_header)
+
+print("\nEVENTS\n======\n")
+pprint(events, width=5)

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -142,3 +142,11 @@ of ``0.1``.
 
 .. exec_code::
    :filename: py3_bindings_read.py
+
+Append to an XCDF file
+^^^^^^^^^^^^^^^^^^^^^^
+
+Now let's add some more data to this existing file.
+
+.. exec_code::
+   :filename: py3_bindings_append.py

--- a/src/pybindings/xcdf/tests/test_xcdf.py
+++ b/src/pybindings/xcdf/tests/test_xcdf.py
@@ -96,3 +96,35 @@ def test_write(tmp_path):
         np.testing.assert_allclose(
             events[1][field_name], expected_second_event[field_name]
         )
+
+
+def test_append(tmp_path):
+    # Create the test file
+    path = str(tmp_path / "test_file_append.xcdf")
+
+    # Write to file
+    with File(path, "w") as f:
+        field_A = f.allocate_uint_field("A", 1, "")
+
+        # event/row 1
+        field_A.add(4)
+
+        f.write()
+
+    # Write to file
+    with File(path, "a") as same_file:
+        field_A = same_file.allocate_uint_field("A", 1, "")
+
+        # event/row 1
+        field_A.add(1)
+
+        same_file.write()
+
+    events = {}
+    with File(path, "r") as input_file:
+        for event_index, event in enumerate(input_file):
+            events[event_index] = event
+
+    expected_data = np.array([4, 1])
+    actual_data = np.array([events[event_index]["A"] for event_index in events])
+    np.testing.assert_array_equal(actual_data, expected_data)


### PR DESCRIPTION
My bad, I noticed that with the latest modifications from #99 append mode was already working.

What was missing was a unit test and an additional example which I added to the Python3 tutorial (re-open the file created in append mode and add some more data)

