### PR TITLE
Allow for writing arrays to fields

### DIFF
--- a/docs/source/examples/py3_bindings_append.py
+++ b/docs/source/examples/py3_bindings_append.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from pprint import pprint
+import numpy as np
 from xcdf import File
 
 test_file = Path.cwd() / Path("example_file_py3bindings.xcd")
@@ -34,10 +35,8 @@ with File(str(test_file), "a") as again_same_file:
 
     # Add data for the second event/row
 
-    field_A.add(2)
-
-    field_B.add(23)
-    field_B.add(34)
+    field_A.add(10)
+    field_B.add(np.linspace(-5.0, 5.0, 10))
 
     again_same_file.write()
 

--- a/docs/source/examples/py3_bindings_write.py
+++ b/docs/source/examples/py3_bindings_write.py
@@ -16,8 +16,8 @@ with File(str(test_file), "w") as f:
 
     # Field "B" is a child of "A", so it needs to contain
     # as many values as the entry in "A" says for this event
-    for i in np.arange(0, 1, 0.25):
-        field_B.add(i)
+    # Let's add the numpy equivalent of [0.  , 0.25, 0.5 , 0.75]
+    field_B.add(np.arange(0, 1, 0.25))
 
     f.write()
 

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -136,7 +136,7 @@ Now let's re-open the same file and read back what we wrote in it.
 
 Notice that, when read back, the data associated to the ``B`` field
 of the first event is the array ``[0. , 0.3, 0.5, 0.8]``
-and not what we injected at writing time, ``[0.  , 0.25, 0.5 , 0.75])``,
+and not what we injected at writing time, ``[0.  , 0.25, 0.5 , 0.75]``,
 because we declared (i.e. allocated) the ``B`` field with a resolution
 of ``0.1``.
 

--- a/include/xcdf/XCDFField.h
+++ b/include/xcdf/XCDFField.h
@@ -117,8 +117,16 @@ class XCDFField : public ConstXCDFField<T> {
     /// object is not allowed
     XCDFField() : fieldData_(NULL) { }
 
-    /// Add a datum to the field
-    void Add(const T value) {FieldData()->Add(value);}
+    /// @brief Add a datum to the field
+    /// @param value Input value
+    void Add(const T value) { FieldData()->Add(value); }
+
+    /// @brief Add an array of values to the field
+    /// @param value Input array of values
+    void Add(const std::vector<T> value) {
+      for (auto it = value.begin(); it != value.end(); ++it)
+        FieldData()->Add(*it);
+    }
 
     XCDFField<T>& operator<<(const T value) {
       FieldData()->Add(value);

--- a/src/pybindings/xcdf/tests/test_xcdf.py
+++ b/src/pybindings/xcdf/tests/test_xcdf.py
@@ -96,3 +96,29 @@ def test_write(tmp_path):
         np.testing.assert_allclose(
             events[1][field_name], expected_second_event[field_name]
         )
+
+
+def test_array_to_field(tmp_path):
+    # Create the test file
+    path = str(tmp_path / "test_array_to_field.xcdf")
+
+    # Write to file
+    with File(path, "w") as f:
+        field_A = f.allocate_uint_field("A", 1, "")
+        field_B = f.allocate_uint_field("B", 1, "A")
+        field_C = f.allocate_int_field("C", 1, "A")
+        field_D = f.allocate_float_field("D", 0.1, "A")
+
+        field_A.add(5)
+        field_B.add(np.arange(5))
+        field_C.add(np.arange(-2, 3))
+        field_D.add(np.linspace(-1, 1, 5))
+
+        f.write()
+
+    # Read back and check contents
+    with File(path, "r") as f:
+        for event in f:
+            np.testing.assert_array_equal(event["B"], np.arange(5))
+            np.testing.assert_array_equal(event["C"], np.arange(-2, 3))
+            np.testing.assert_array_equal(event["D"], np.linspace(-1, 1, 5))

--- a/src/pybindings/xcdf/xcdf.cpp
+++ b/src/pybindings/xcdf/xcdf.cpp
@@ -129,17 +129,39 @@ PYBIND11_MODULE(xcdf, m) {
   // XCDFUnsignedIntegerField
   py::class_<XCDFField<uint64_t>>(m, "XCDFUnsignedIntegerField",
                                   "Field with unsigned integer data.")
-      .def("add", &XCDFField<uint64_t>::Add);
+      .def("add",
+           static_cast<void (XCDFField<uint64_t>::*)(uint64_t)>(
+               &XCDFField<uint64_t>::Add),
+           "Add a datum to the field.")
+      .def("add",
+           static_cast<void (XCDFField<uint64_t>::*)(
+               const std::vector<uint64_t>)>(&XCDFField<uint64_t>::Add),
+           "Add an array of data to the field.");
 
   // XCDFSignedIntegerField
   py::class_<XCDFField<int64_t>>(m, "XCDFSignedIntegerField",
                                  "Field with signed integer data.")
-      .def("add", &XCDFField<int64_t>::Add);
+      .def("add",
+           static_cast<void (XCDFField<int64_t>::*)(int64_t)>(
+               &XCDFField<int64_t>::Add),
+           "Add a datum to the field.")
+      .def(
+          "add",
+          static_cast<void (XCDFField<int64_t>::*)(const std::vector<int64_t>)>(
+              &XCDFField<int64_t>::Add),
+          "Add an array of data to the field.");
 
   // XCDFFloatingPointField
   py::class_<XCDFField<double>>(m, "XCDFFloatingPointField",
                                 "Field with floating point data.")
-      .def("add", &XCDFField<double>::Add);
+      .def("add",
+           static_cast<void (XCDFField<double>::*)(double)>(
+               &XCDFField<double>::Add),
+           "Add a datum to the field.")
+      .def("add",
+           static_cast<void (XCDFField<double>::*)(const std::vector<double>)>(
+               &XCDFField<double>::Add),
+           "Add an array of data to the field.");
 
   py::class_<XCDFFieldDescriptor>(
       m, "FieldDescriptor", "Class that summarizes the properties of a field.")


### PR DESCRIPTION
#### Context

In #99 I wanted to expose the minimum available API to write to file with Python3.

Though, I noticed that the Add method of XCDFField allowed only to add a single value at the time, so in Python one would have to perform for cycles for each array to write, e.g. what is currently in the writing example of the Python tutorial,

```python
for i in np.arange(0, 1, 0.25):
        field_B.add(i)
```

which obviously not scalable.

#### Implementation

I added an overloaded method of `XCDFField::Add` which instead of eating a single value eats a `std::vector` and inside it just loops over it calling `XCDFFieldData::Add` on each value.

I added a dedicated unit test and updated the documentation accordingly.

With this we can do, e.g.

```python
field_B.add(np.arange(0, 1, 0.25))
```