### PR TITLE
Require C++11 compatible compilation at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ project(xcdf
   HOMEPAGE_URL https://github.com/jimbraun/XCDF
   LANGUAGES CXX C)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 ADD_DEFINITIONS("-Wall -O2")
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This MR addresses part of #103 by requiring C++11 as the C++ standard when CMake generates the project to build.