### PR TITLE
Add workflow for deployment to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to PyPi
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+  publish-to-pypi:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<package-name>  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR implements a new GitHub workflow based on the [current best practice](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) recommended by the Python Packaging Authority.

I already created a “pending” trusted publisher on PyPI with my account for this project and the workflow is set to run only when a release is published (whatever the tag name).

@maxnoe could you give a second look at this? My biggest doubt is about how to treat the git-metadata version which is now read by the CMake configuration, but still hardcoded in `setup.cfg` to "4.0.0" (which is still unreleased); from the setuptools guide I don't see dynamic version available but from the `pyproject.toml` implementation - should this part be done like in e.g. ctapipe with the `version.py` file?

I'll keep it as a draft PR until we have sorted out if it's correct.